### PR TITLE
codyworthen/management-client-config-fix

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -40,7 +40,11 @@ class InstallCommand extends Command
 	{
 		parent::__construct();
 
-		$this->managementClient = new ManagementClient(config('storyblok.oauth_token'));
+        $this->managementClient = new ManagementClient(
+            apiKey: config('storyblok.oauth_token'),
+            apiEndpoint: config('storyblok.management_api_base_url'),
+            ssl: config('storyblok.use_ssl')
+        );
 	}
 
 	/**

--- a/src/Support/ComponentGroupMaker.php
+++ b/src/Support/ComponentGroupMaker.php
@@ -35,7 +35,11 @@ class ComponentGroupMaker
 	{
 		$this->command = $command;
 
-		$this->managementClient = new ManagementClient(config('storyblok.oauth_token'));
+        $this->managementClient = new ManagementClient(
+            apiKey: config('storyblok.oauth_token'),
+            apiEndpoint: config('storyblok.management_api_base_url'),
+            ssl: config('storyblok.use_ssl')
+        );
 	}
 
 	/**

--- a/src/Support/ComponentMaker.php
+++ b/src/Support/ComponentMaker.php
@@ -44,7 +44,11 @@ class ComponentMaker
 		$this->command = $command;
 		$this->schema = $schema;
 
-		$this->managementClient = new ManagementClient(config('storyblok.oauth_token'));
+        $this->managementClient = new ManagementClient(
+            apiKey: config('storyblok.oauth_token'),
+            apiEndpoint: config('storyblok.management_api_base_url'),
+            ssl: config('storyblok.use_ssl')
+        );
 	}
 
 	/**

--- a/stubs/views/blocks/lsf-input.blade.php
+++ b/stubs/views/blocks/lsf-input.blade.php
@@ -5,7 +5,7 @@
 <label>
 	<span>{{ $block->label }}</span>
 
-	<input type="{{ $block->type }}" name="{{ $block->name }}" placeholder="{{ $block->placeholder }}" value="{{ data_get(old(), $block->input_dot_name) }}">
+	<input type="{{ $block->type }}" name="{{ $block->name }}" placeholder="{{ $block->placeholder }}" value="{{ data_get(old() ? old() : '', $block->input_dot_name) }}">
 
 	@error($block->input_dot_name)
 		<small>{{ $message }}</small>


### PR DESCRIPTION
This allows the `laravel-storyblok-forms` package to be used in regions such as the US.

This also fixes an error I encountered when playing around with a form with a basic text input. I was getting an error where an empty array was being passed (returned from `old()` when the input didn't have a value yet). This was just a quick fix I implemented to get a proof of concept with this package to work, so there's probably a better solution.